### PR TITLE
Feature/inheritance

### DIFF
--- a/boomstick/boomstick.py
+++ b/boomstick/boomstick.py
@@ -10,13 +10,14 @@ See LICENSE.MD
 """
 
 import logging
+
 import coloredlogs
 
 
-class Logger:
+class Logger(logging.Logger):
 
-    def __init__(self, logfile: str):
-        self.log = logging.getLogger(f"{__name__}")
+    def __init__(self, name, logfile: str, level=logging.NOTSET, ):
+        super().__init__(name=name, level=level)
 
         # create a handler for said logger...
         file_logger = logging.FileHandler(logfile, 'a', encoding="utf-8")
@@ -28,14 +29,14 @@ class Logger:
         file_logger.setFormatter(file_logger_format)
 
         # add the handler to the log.
-        logging.getLogger(f"{__name__}").addHandler(file_logger)
+        self.addHandler(file_logger)
 
         # set proper severity level
-        self.log.setLevel(10)
+        self.setLevel(10)
 
         # add Console logging
         console = logging.StreamHandler()
-        logging.getLogger(f"{__name__}").addHandler(console)
+        self.addHandler(console)
 
         # add console logging format
         console_format = logging.Formatter(log_format)
@@ -55,7 +56,7 @@ class Logger:
                            'name': {'color': 'yellow', 'bright': True}}
 
         # coloredlogs hook
-        coloredlogs.install(handler=f"{__name__}",
+        coloredlogs.install(handler=f"{name}",
                             level='a',
                             fmt=log_format,
                             level_styles=log_levelstyles,
@@ -65,6 +66,6 @@ class Logger:
                             )
 
         # disable propagation
-        self.log.propagate = False
+        self.propagate = False
 
-        self.log.info("Boomstick Loaded and ready for logging.")
+        self.info("Boomstick Loaded and ready for logging.")

--- a/boomstick/boomstick.py
+++ b/boomstick/boomstick.py
@@ -56,7 +56,7 @@ class Logger(logging.Logger):
                            'name': {'color': 'yellow', 'bright': True}}
 
         # coloredlogs hook
-        coloredlogs.install(handler=f"{name}",
+        coloredlogs.install(handler=name,
                             level='a',
                             fmt=log_format,
                             level_styles=log_levelstyles,


### PR DESCRIPTION
This Pr makes `boomstick.Logger` inherit from `logging.Logger` (stdlib).

This allows us to extend the existing `logging.Logger` provided by the stdlib, without re-implementing or wrapping the standard library.

By doing so, we greatly reduce technical debt and difficulty of implementation while also making us more resilient to upstream changes should logging change between python versions.


demo:
```py
>>> from boomstick import Logger
>>> log = Logger("test", logfile="test.log")
<2019-01-12 13:46:13,201 test> [INFO] Boomstick Loaded and ready for logging.
>>> log.info("hello world!")
<2019-01-12 13:46:22,215 test> [INFO] hello world!
>>> from logging import getLogger
>>> bar = getLogger('test.potato')
>>> bar.info("potatoes!")
<2019-01-12 13:51:29 test.potato> [INFO] potatoes!
```