### PR TITLE
Remove initialization message

### DIFF
--- a/mechachainsaw/mechachainsaw.py
+++ b/mechachainsaw/mechachainsaw.py
@@ -80,8 +80,6 @@ class Logger(logging.Logger):
         # disable propagation
         self.propagate = False
 
-        self.debug("Chainsaw Loaded and ready for logging.")
-
     def demo(self):
         self.debug("Example Debug Statement")
         self.info("Example INFO Statement")


### PR DESCRIPTION
`__init__` is called for every instantiation of the logger, including child loggers. In a large codebase with many modules, this message will end up being repeated often.

Example:
```
<2019-08-13 09:29:58 main> [DEBUG] Chainsaw Loaded and ready for logging.
<2019-08-13 09:29:58 main> [DEBUG] aaa
<2019-08-13 09:29:58 main.module1> [DEBUG] Chainsaw Loaded and ready for logging.
<2019-08-13 09:29:58 main.module1> [DEBUG] bbb
<2019-08-13 09:29:58 main.module2> [DEBUG] Chainsaw Loaded and ready for logging.
<2019-08-13 09:29:58 main.module2> [DEBUG] ccc

```